### PR TITLE
0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Framework :: Pytest",
 ]
-version = "0.4.2"
+version = "0.4.3"
 dependencies = ["pytest >= 3.6", "freezegun"]
 readme = "README.rst"
 description = "Pytest plugin providing a fixture interface for spulec/freezegun"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pytest_freezer"
 authors = [{name = "Wim Glenn", email = "hey@wimglenn.com"}]
-license = {file = "LICENSE"}
+license = "MIT"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Framework :: Pytest",


### PR DESCRIPTION
- added docstring to the fixture. this shows in the output of `pytest --fixtures`
- fixed license metadata so the whole text is not rendering on PyPI landing page :) 