### PR TITLE
Add testing on Python 3.7, 3.11 and 3.12-dev in CI. Remove testing on 3.6 and 3.10.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.11", "3.12-dev"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 version = "0.4.6"
 dependencies = ["pytest >= 3.6", "freezegun >= 1.0"]
-requires-python = ">= 3.6"
+requires-python = ">= 3.7"
 readme = "README.rst"
 description = "Pytest plugin providing a fixture interface for spulec/freezegun"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 version = "0.4.6"
 dependencies = ["pytest >= 3.6", "freezegun >= 1.0"]
-requires-python = ">= 3.7"
+requires-python = ">= 3.6"
 readme = "README.rst"
 description = "Pytest plugin providing a fixture interface for spulec/freezegun"
 


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also test Python 3.12-dev and drop EOL 3.6.

* https://devguide.python.org/versions/