### PR TITLE
Do not install stray files to site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Homepage = "https://github.com/pytest-dev/pytest-freezer"
 [project.entry-points.pytest11]
 freezer = "pytest_freezer"
 
-[tool.hatch.build]
+[tool.hatch.build.targets.sdist]
 include = [
     "LICENSE",
     "README.rst",


### PR DESCRIPTION
Fix `pyproject.toml` to apply includes to sdist target and not wheels. Otherwise, the following files end up being installed to site-packages:

 *   /usr/lib/python*/site-packages/pyproject.toml
 *   /usr/lib/python*/site-packages/README.rst
 *   /usr/lib/python*/site-packages/LICENSE
 *   /usr/lib/python*/site-packages/tests