### PR TITLE
fix: pytest-freezer actually depends on freezegun>=1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Framework :: Pytest",
 ]
 version = "0.4.8"
-dependencies = ["pytest >= 3.6", "freezegun >= 1.0"]
+dependencies = ["pytest >= 3.6", "freezegun >= 1.1"]
 requires-python = ">= 3.6"
 readme = "README.rst"
 description = "Pytest plugin providing a fixture interface for spulec/freezegun"


### PR DESCRIPTION
pytest_freezer.py tries to run freezegun.configure, which is only available from freezegun 1.1.